### PR TITLE
Add build for 0.2.4. release

### DIFF
--- a/0.2.4/cli/Dockerfile
+++ b/0.2.4/cli/Dockerfile
@@ -1,0 +1,39 @@
+# Build OpenRCT2
+FROM ubuntu:19.04 AS build-env
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y git cmake pkg-config ninja-build clang-6.0 libsdl2-dev libspeexdsp-dev libjansson-dev libcurl4-openssl-dev libcrypto++-dev libfontconfig1-dev libfreetype6-dev libpng-dev libzip-dev libssl-dev libicu-dev \
+ && ln -s /usr/bin/clang-6.0 /usr/bin/clang \
+ && ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
+
+ENV OPENRCT2_REF v0.2.4
+WORKDIR /openrct2
+RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.com/OpenRCT2/OpenRCT2 . \
+ && mkdir build \
+ && cd build \
+ && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr -DCMAKE_INSTALL_LIBDIR=/openrct2-install/usr/lib \
+ && ninja -k0 install
+
+# Build runtime image
+FROM ubuntu:19.04
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get install --no-install-recommends -y rsync ca-certificates libjansson4 libpng16-16 libzip5 libcurl4 libfreetype6 libfontconfig1 libicu63
+
+# Install OpenRCT2
+COPY --from=build-env /openrct2-install /openrct2-install
+RUN rsync -a /openrct2-install/* / \
+ && rm -rf /openrct2-install \
+ && openrct2-cli --version
+
+# Set up ordinary user
+RUN useradd -m openrct2
+USER openrct2
+WORKDIR /home/openrct2
+EXPOSE 11753
+
+# Test run and scan
+RUN openrct2-cli --version \
+ && openrct2-cli scan-objects
+
+# Done
+ENTRYPOINT ["openrct2-cli"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ It will then host a new server and load the saved game `mypark.sv6` located in t
 v0.2.3 onwards are based on Ubuntu 19.04 (amd64). All previous tags are based on Ubuntu 18.04 (amd64).
 
 - [`develop` (*develop/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/develop/cli/Dockerfile)
-- [`0.2.3`, `latest` (*0.2.3/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.3/cli/Dockerfile)
+- [`0.2.4`, `latest` (*0.2.4/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.4/cli/Dockerfile)
+- [`0.2.3` (*0.2.3/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.3/cli/Dockerfile)
 - [`0.2.2` (*0.2.2/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.2/cli/Dockerfile)
 - [`0.2.1` (*0.2.1/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.1/cli/Dockerfile)
 - [`0.2.0` (*0.2.0/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.0/cli/Dockerfile)


### PR DESCRIPTION
Heya 👋,

I wanted to start a container but my game told me that there was a version mismatch 😄.
This PR should take care of creating a 0.2.4 docker image release.

### What has been done:
I literally copied & pasted the 0.2.3 release into a 0.2.4 and changed the version number 🙈. It failed building on a Linux environment, maybe because it had no X or GPU?  Building locally on a Mac did work though.

### How to test:
1. Checkout PR
1. Run build
1. Acknowledge it works

### Notes:
- How can we make sure that `latest` will refer to 0.2.4?  
- Let me know if you have any thoughts or suggestions 😄 