### PR TITLE
Add Dockerfile for v0.2.6

### DIFF
--- a/0.2.6/cli/Dockerfile
+++ b/0.2.6/cli/Dockerfile
@@ -1,0 +1,40 @@
+# Build OpenRCT2
+FROM ubuntu:20.04 AS build-env
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y git cmake pkg-config ninja-build clang-10 libsdl2-dev libspeexdsp-dev libjansson-dev libcurl4-openssl-dev libcrypto++-dev libfontconfig1-dev libfreetype6-dev libpng-dev libzip-dev libssl-dev libicu-dev \
+ && ln -s /usr/bin/clang-10 /usr/bin/clang \
+ && ln -s /usr/bin/clang++-10 /usr/bin/clang++
+
+ENV OPENRCT2_REF v0.2.6
+WORKDIR /openrct2
+RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.com/OpenRCT2/OpenRCT2 . \
+ && mkdir build \
+ && cd build \
+ && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr -DCMAKE_INSTALL_LIBDIR=/openrct2-install/usr/lib \
+ && ninja -k0 install
+
+# Build runtime image
+FROM ubuntu:20.04
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get install --no-install-recommends -y rsync ca-certificates libjansson4 libpng16-16 libzip5 libcurl4 libfreetype6 libfontconfig1 libicu66
+
+# Install OpenRCT2
+COPY --from=build-env /openrct2-install /openrct2-install
+RUN rsync -a /openrct2-install/* / \
+ && rm -rf /openrct2-install \
+ && openrct2-cli --version
+
+# Set up ordinary user
+RUN useradd -m openrct2
+USER openrct2
+WORKDIR /home/openrct2
+EXPOSE 11753
+
+# Test run and scan
+RUN openrct2-cli --version \
+ && openrct2-cli scan-objects
+
+# Done
+ENTRYPOINT ["openrct2-cli"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ It will then host a new server and load the saved game `mypark.sv6` located in t
 v0.2.5 onwards are based on Ubuntu 20.04 (amd64). v0.2.4 and v0.2.3 use Ubuntu 19.04 (amd64), previous tags are based on Ubuntu 18.04 (amd64).
 
 - [`develop` (*develop/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/develop/cli/Dockerfile)
-- [`0.2.5`, `latest` (*0.2.5/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.5/cli/Dockerfile)
+- [`0.2.6`, `latest` (*0.2.6/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.6/cli/Dockerfile)
+- [`0.2.5` (*0.2.5/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.5/cli/Dockerfile)
 - [`0.2.4` (*0.2.4/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.4/cli/Dockerfile)
 - [`0.2.3` (*0.2.3/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.3/cli/Dockerfile)
 - [`0.2.2` (*0.2.2/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.2/cli/Dockerfile)


### PR DESCRIPTION
Howdy,

Nothing too exciting, just a version bump based on the Dockerfile for v0.2.5, with corresponding updates to the README. I tested it by building/running on a local server and connecting from another machine.

Let me know if there's an issue, thanks!