### PR TITLE
Optimize develop Dockerfile and add Dockerfile for v0.3.0

### DIFF
--- a/0.3.0/cli/Dockerfile
+++ b/0.3.0/cli/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
  && ln -s /usr/bin/clang-10 /usr/bin/clang \
  && ln -s /usr/bin/clang++-10 /usr/bin/clang++
 
-ENV OPENRCT2_REF develop
+ENV OPENRCT2_REF v0.3.0
 WORKDIR /openrct2
 RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.com/OpenRCT2/OpenRCT2 . \
  && mkdir build \

--- a/0.3.0/cli/Dockerfile
+++ b/0.3.0/cli/Dockerfile
@@ -12,8 +12,9 @@ WORKDIR /openrct2
 RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.com/OpenRCT2/OpenRCT2 . \
  && mkdir build \
  && cd build \
- && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr -DCMAKE_INSTALL_LIBDIR=/openrct2-install/usr/lib \
- && ninja -k0 install
+ && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr \
+ && ninja -k0 install \
+ && rm /openrct2-install/usr/lib/libopenrct2.a
 
 # Build runtime image
 FROM ubuntu:20.04

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ It will then host a new server and load the saved game `mypark.sv6` located in t
 v0.2.5 onwards are based on Ubuntu 20.04 (amd64). v0.2.4 and v0.2.3 use Ubuntu 19.04 (amd64), previous tags are based on Ubuntu 18.04 (amd64).
 
 - [`develop` (*develop/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/develop/cli/Dockerfile)
-- [`0.2.6`, `latest` (*0.2.6/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.6/cli/Dockerfile)
+- [`0.3.0`, `latest` (*0.3.0/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.3.0/cli/Dockerfile)
+- [`0.2.6` (*0.2.6/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.6/cli/Dockerfile)
 - [`0.2.5` (*0.2.5/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.5/cli/Dockerfile)
 - [`0.2.4` (*0.2.4/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.4/cli/Dockerfile)
 - [`0.2.3` (*0.2.3/cli/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker/blob/master/0.2.3/cli/Dockerfile)

--- a/develop/cli/Dockerfile
+++ b/develop/cli/Dockerfile
@@ -12,8 +12,9 @@ WORKDIR /openrct2
 RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.com/OpenRCT2/OpenRCT2 . \
  && mkdir build \
  && cd build \
- && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr -DCMAKE_INSTALL_LIBDIR=/openrct2-install/usr/lib \
- && ninja -k0 install
+ && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr \
+ && ninja -k0 install \
+ && rm /openrct2-install/usr/lib/libopenrct2.a
 
 # Build runtime image
 FROM ubuntu:20.04


### PR DESCRIPTION
Reduced the image size by about 55MB by:

- Removing apt update files
- Combining RUN layers
- Removing the [apt upgrade](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get) command
- Removing the libopenrct2 dev library