### PR TITLE
Use ARG tag instead of ENV

### DIFF
--- a/develop/cli/Dockerfile
+++ b/develop/cli/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
  && ln -s /usr/bin/clang-10 /usr/bin/clang \
  && ln -s /usr/bin/clang++-10 /usr/bin/clang++
 
-ENV OPENRCT2_REF develop
+ARG OPENRCT2_REF=develop
 WORKDIR /openrct2
 RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.com/OpenRCT2/OpenRCT2 . \
  && mkdir build \


### PR DESCRIPTION
Works the same as `ENV`, but can also be passed in during the build process:

```
docker build --build-arg "OPENRCT2_REF=v0.4.4" -t "openrct2/openrct2-cli:release" -f ./develop/cli/Dockerfile .
```