### PR TITLE
Update ci.yml - Changing CI release to v0.4.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         # List of tags to build and upload, remember to update this
-        tag: [0.4.19]
+        tag: [0.4.20]
     env:
       dockertag: ${{ matrix.tag }}
       dockerimg: openrct2/openrct2-cli
-      dockerlst: 0.4.19
+      dockerlst: 0.4.20
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Seems like the tag wasn't updated. Version v0.4.20 is missing in dockerhub, latest builds v0.4.18 :

```
sudo docker run --rm openrct2/openrct2-cli:latest --version
OpenRCT2, v0.4.18 (8c19879 on HEAD)
Linux (x86-64)
Network version: 0.4.18-0
Plugin API version: 103
Current park file version: 48
Minimum park file version: 45
Breakpad support disabled
```