### PR TITLE
fix: build target changed from "g2" to "graphics"

### DIFF
--- a/develop/cli/Dockerfile
+++ b/develop/cli/Dockerfile
@@ -11,7 +11,7 @@ RUN git -c http.sslVerify=false clone --depth 1 -b $OPENRCT2_REF https://github.
  && mkdir build \
  && cd build \
  && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/openrct2-install/usr -DDISABLE_GUI=ON -DENABLE_HEADERS_CHECK=OFF \
- && ninja -k0 install \
+ && ninja -k0 graphics install \
  && rm /openrct2-install/usr/lib/libopenrct2.a
 
 # Build runtime image


### PR DESCRIPTION
Fixes build failures seen in [OpenRCT2/OpenRCT2](https://github.com/OpenRCT2/OpenRCT2)'s CI docker builds.

Though I have to ask, does an openrct2-cli docker image even need g2.dat and fonts.dat?